### PR TITLE
Update FcmChannel.php

### DIFF
--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -42,6 +42,10 @@ class FcmChannel
     {
         /** @var FcmMessage $message */
         $message = $notification->toFcm($notifiable);
+        
+        if (is_null($message)) {
+            return;
+        }    
 
         if (is_null($message->getTo()) && is_null($message->getCondition())) {
             if (! $to = $notifiable->routeNotificationFor('fcm', $notification)) {


### PR DESCRIPTION
I would to prevent call code in toFcm because is little expensive (many relations loaded to get message content) if notifiable (User in my case) has disabled notifications or he never logged into app.

```php
    /**
     * @param  User $notifiable
     * @return FcmMessage
     */
    public function toFcm($notifiable)
    {
        if ($notifiable->shouldBeNotified()) {

            $fcmData = [
                'id'              => $this->message->id,
                // and lot of stuff (many relations)
            ];
            $message = (new FcmMessage())->data($fcmData);
            $message->priority(FcmMessage::PRIORITY_HIGH);
            return $message;

        }

        return new FcmMessage; // null or false more readable? 
    }
```