### PR TITLE
Changed service provider register method

### DIFF
--- a/src/FcmNotificationServiceProvider.php
+++ b/src/FcmNotificationServiceProvider.php
@@ -3,8 +3,9 @@
 namespace Benwilkins\FCM;
 
 use GuzzleHttp\Client;
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Notifications\ChannelManager;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\ServiceProvider;
 
 /**
  * Class FcmNotificationServiceProvider.
@@ -15,9 +16,11 @@ class FcmNotificationServiceProvider extends ServiceProvider
      * Register.
      */
     public function register()
-    {       
-        $this->app->make(ChannelManager::class)->extend('fcm', function () {
-            return new FcmChannel(app(Client::class), config('services.fcm.key'));
+    {
+        Notification::resolved(function (ChannelManager $service) {
+            $service->extend('fcm', function () {
+                return new FcmChannel(app(Client::class), config('services.fcm.key'));
+            });
         });
     }
 }


### PR DESCRIPTION
Changed the way the FcmChannel is registered, because the previous method was in conflict with official Laravel Nexmo notification channel ([laravel/nexmo-notification-channel](https://github.com/laravel/nexmo-notification-channel)). It was somehow preventing the initialization of nexmo channel, throwing exception "Driver [nexmo] not supported" when trying to use the nexmo channel. This fixed the problem and both channels now work.

Solution is based on [this commit](https://github.com/laravel/nexmo-notification-channel/commit/3c8e8fb67f7495ce90cf0a940ad48dc21ac233ec) that is in itself based on [this one](https://github.com/laravel/framework/pull/26824).

Requires Laravel 5.7+