### PR TITLE
Support Laravel ^6.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# https://git-scm.com/book/en/Customizing-Git-Git-Attributes
+
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Export ignores
+.github export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.editorconfig export-ignore
+.travis.yml export-ignore
+.styleci.yml export-ignore
+phpunit.xml.dist export-ignore
+composer.lock export-ignore
+CHANGELOG.md export-ignore
+tests export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 composer.lock
 .env
 .phpunit.result.cache
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-
 language: php
 
 php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   matrix:
@@ -16,7 +16,7 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - composer test -- --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Ben Wilkins
+Copyright (c) 2019 Ben Wilkins
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# laravel-fcm-notification
+# Laravel FCM Notification
 Laravel FCM (Firebase Cloud Messaging) Notification Channel
 
-[![Latest Version](https://img.shields.io/github/release/benwilkins/laravel-fcm-notification.svg?style=flat-square)](https://github.com/benwilkins/laravel-fcm-notification/releases)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![GitHub tag](https://badgen.net/github/tag/benwilkins/laravel-fcm-notification)](https://github.com/benwilkins/laravel-fcm-notification/releases)
+[![Packagist](https://badgen.net/packagist/v/benwilkins/laravel-fcm-notification)](https://packagist.org/packages/benwilkins/laravel-fcm-notification)
+[![Downloads](https://badgen.net/packagist/dt/benwilkins/laravel-fcm-notification)](https://packagist.org/packages/benwilkins/laravel-fcm-notification)
+[![Build Status](https://travis-ci.com/benwilkins/laravel-fcm-notification.svg)](https://travis-ci.com/benwilkins/laravel-fcm-notification)
+[![License](https://badgen.net/packagist/license/benwilkins/laravel-fcm-notification)](https://packagist.org/packages/benwilkins/laravel-fcm-notification)
 
-Use this package to send push notifications via Laravel to Firebase Cloud Messaging. Laravel 5.3+ required.
+Use this package to send push notifications via Laravel to Firebase Cloud Messaging. Laravel 5.5+ required.
 
 This package works only with [Legacy HTTP Server Protocol](https://firebase.google.com/docs/cloud-messaging/http-server-ref)
 
@@ -13,7 +16,7 @@ This package works only with [Legacy HTTP Server Protocol](https://firebase.goog
 This package can be installed through Composer.
 
 ``` bash
-composer require benwilkins/laravel-fcm-notification:dev-master
+composer require benwilkins/laravel-fcm-notification
 ```
 
 If installing on < Laravel 5.5 then add the service provider:
@@ -38,7 +41,7 @@ return [
      * Add the Firebase API key
      */
     'fcm' => [
-        'key' => ''
+        'key' => env('FCM_SECRET_KEY')
      ]
 ];
 ```
@@ -164,7 +167,7 @@ public function toFcm($notifiable)
 
 ## Interpreting a Response
 
-To proccess any laravel notification channel response check [Laravel Notification Events](https://laravel.com/docs/5.5/notifications#notification-events)
+To process any laravel notification channel response check [Laravel Notification Events](https://laravel.com/docs/6.0/notifications#notification-events)
 
 This channel return a json array response: 
 ```json
@@ -173,7 +176,7 @@ This channel return a json array response:
     "success": "number",
     "failure": "number",
     "canonical_ids": "number",
-    "results": "array",
+    "results": "array"
  }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -2,20 +2,25 @@
   "name": "benwilkins/laravel-fcm-notification",
   "description": "Laravel FCM (Firebase Cloud Messaging) Notification Channel",
   "license": "MIT",
+  "keywords": [
+    "laravel",
+    "fcm",
+    "firebase",
+    "notifications"
+  ],
   "authors": [
     {
       "name": "Ben Wilkins",
       "email": "bentwilkins@gmail.com"
     }
   ],
-  "minimum-stability": "dev",
   "require": {
     "php": ">=5.6.4",
     "guzzlehttp/guzzle": "^6.2",
-    "illuminate/notifications": "5.3.*|5.4.*|5.5.*|5.5.*|5.6.*|5.7.*|5.8.*",
-    "illuminate/queue": "5.3.*|5.4.*|5.5.*|5.5.*|5.6.*|5.7.*|5.8.*",
-    "illuminate/support": "5.3.*|5.4.*|5.5.*|5.5.*|5.6.*|5.7.*|5.8.*",
-    "illuminate/config": "5.3.*|5.4.*|5.5.*|5.5.*|5.6.*|5.7.*|5.8.*"
+    "illuminate/notifications": "~5.3|^6.0",
+    "illuminate/queue": "~5.3|^6.0",
+    "illuminate/support": "~5.3|^6.0",
+    "illuminate/config": "~5.3|^6.0"
   },
   "require-dev": {
     "mockery/mockery": "~1.0",
@@ -42,6 +47,9 @@
     "test": "vendor/bin/phpunit"
   },
   "config": {
-    "sort-packages": true
-  }
+    "sort-packages": true,
+    "preferred-install": "dist"
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
->
+<phpunit
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        bootstrap="vendor/autoload.php"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        processIsolation="false"
+        stopOnFailure="false">
     <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
+        <testsuite name="Test Suite">
+            <directory suffix=".php">./tests</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -23,10 +23,10 @@ class FcmChannel
     /**
      * @var string
      */
-    private $apikey;
+    private $apiKey;
 
     /**
-     * @param Client $client
+     * @param  Client  $client
      */
     public function __construct(Client $client, $apiKey)
     {
@@ -35,8 +35,9 @@ class FcmChannel
     }
 
     /**
-     * @param mixed $notifiable
-     * @param Notification $notification
+     * @param  mixed  $notifiable
+     * @param  Notification  $notification
+     * @return mixed
      */
     public function send($notifiable, Notification $notification)
     {
@@ -44,7 +45,7 @@ class FcmChannel
         $message = $notification->toFcm($notifiable);
 
         if (is_null($message->getTo()) && is_null($message->getCondition())) {
-            if (! $to = $notifiable->routeNotificationFor('fcm', $notification)) {
+            if (!$to = $notifiable->routeNotificationFor('fcm', $notification)) {
                 return;
             }
 
@@ -55,7 +56,7 @@ class FcmChannel
             'headers' => array_merge(
                 [
                     'Authorization' => 'key='.$this->apiKey,
-                    'Content-Type'  => 'application/json',
+                    'Content-Type' => 'application/json',
                 ],
                 $message->getHeaders()
             ),


### PR DESCRIPTION
Laravel 6 will be released on Sep 3.

I was wondering why Travis-CI was not triggered for this PR. 
Please enable [travis-ci](https://travis-ci.org/benwilkins/laravel-fcm-notification) for this repo.

Laravel 6 will be a LTS release, so i have dropped all previous version support.