### PR TITLE
Allow guzzle v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=5.6.4",
-    "guzzlehttp/guzzle": "^6.2",
+    "guzzlehttp/guzzle": "^6.2|^7.0",
     "illuminate/notifications": "~5.3|^6.0|^7.0",
     "illuminate/queue": "~5.3|^6.0|^7.0",
     "illuminate/support": "~5.3|^6.0|^7.0",


### PR DESCRIPTION
Hi, @benwilkins 

Guzzle http v7.0 has been released, it should be working fine with this package.

https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#60-to-70
